### PR TITLE
Clarify Debian CUDA package usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,18 @@
 # nvidia-driver
-NVIDIA Driver + CUDA Toolkit Installer for Debian 11/12/13
+NVIDIA Driver + CUDA Toolkit Installer for Debian 12/13
 
-This script installs the latest **NVIDIA GPU drivers** and the **CUDA Toolkit** on **Debian 11 (Bullseye)**, **Debian 12 (Bookworm)**, and **Debian 13 (Trixie)** — automatically and reliably.  
-It sets up the official NVIDIA repositories, installs drivers & libraries, and configures environment variables system-wide.
+This script installs **NVIDIA GPU drivers** and the **CUDA Toolkit** on **Debian 12 (Bookworm)** and **Debian 13 (Trixie)** — automatically and reliably.  
+It uses Debian’s own packages (APT-first, no NVIDIA repo by default) for a stable, Debian-managed setup.
 
 ---
 
 ## ✨ Features
-- ✅ Auto-detects Debian **11/12/13** and **amd64/arm64** architecture
-- ✅ Uses official NVIDIA CUDA APT repository
-- ✅ **Debian 13 fallback:** tries `debian13` repo first; if unavailable, falls back to `debian12` with a warning
+- ✅ Auto-detects Debian **12/13** and **amd64/arm64** architecture
 - ✅ Installs build tools: `build-essential`, `dkms`, `linux-headers-$(uname -r)`
-- ✅ Installs driver + CUDA via the `cuda` meta-package
-- ✅ Sets CUDA env vars via `/etc/profile.d/cuda.sh`
+- ✅ Installs CUDA via the Debian package: `nvidia-cuda-toolkit`
 - ✅ Optionally blacklists **nouveau** to avoid conflicts
 - ✅ Warns if **Secure Boot** is enabled
 
-
-🧭 Debian 13 (Trixie) Notes
-
-The script first tries NVIDIA’s debian13 repo.
-If it’s not available yet, it falls back to debian12. This often works, but compatibility depends on kernel & driver versions.
-
-If the module fails to build or load, check kernel headers, Secure Boot, and nouveau status (see Troubleshooting).
 
 🛡️ Secure Boot
 
@@ -55,19 +45,18 @@ DKMS build fails: Ensure headers match the running kernel:
 uname -r
 apt-cache policy linux-headers-$(uname -r)
 
+Unable to locate package cuda: Debian repos do not ship the `cuda` meta-package. Use `nvidia-cuda-toolkit` (this script does) or add NVIDIA’s CUDA repo explicitly.
 
-nvidia-smi not found: Ensure /usr/local/cuda/bin and driver packages are installed; re-login or source /etc/profile.d/cuda.sh.
+
+nvidia-smi not found: Ensure driver packages are installed and reboot if needed.
 
 
 🧩 Uninstall
 
 To remove CUDA & drivers:
 
-sudo apt remove --purge 'cuda*' 'nvidia*'
-sudo rm -f /etc/apt/sources.list.d/nvidia-cuda.list \
-           /usr/share/keyrings/nvidia-cuda-archive-keyring.gpg \
-           /etc/profile.d/cuda.sh \
-           /etc/modprobe.d/blacklist-nouveau.conf
+sudo apt remove --purge 'nvidia-cuda-toolkit*' 'nvidia*'
+sudo rm -f /etc/modprobe.d/blacklist-nouveau.conf
 sudo update-initramfs -u
 sudo apt autoremove -y
 sudo reboot


### PR DESCRIPTION
### Motivation
- A user reported "Unable to locate package cuda" on Debian 12, indicating the README referenced an incorrect install path.
- The script favors Debian-managed packages rather than NVIDIA's `cuda` meta-package, so documentation should reflect the actual behavior.
- Remove outdated references to Debian 11 and NVIDIA repo fallback that no longer match the script.
- Make uninstall and troubleshooting guidance clearer for Debian 12/13 users.

### Description
- Updated `README.md` to list supported releases as Debian 12/13 and to adjust the feature list accordingly.
- Replaced references to the `cuda` meta-package and NVIDIA repo with Debian-first guidance and `nvidia-cuda-toolkit` usage.
- Added a troubleshooting note explicitly stating "Unable to locate package cuda" and advising to use `nvidia-cuda-toolkit` or add NVIDIA’s CUDA repo.
- Simplified uninstall instructions to remove `nvidia-cuda-toolkit*` and cleaned up unnecessary file-removal steps.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bbcca519883289afbea6f5292c328)