### PR TITLE
Handle missing APT source files in installer

### DIFF
--- a/install-nvidia-cuda.sh
+++ b/install-nvidia-cuda.sh
@@ -139,6 +139,11 @@ check_nonfree_sources() {
     sources+=(/etc/apt/sources.list.d/*.list)
   fi
 
+  if (( ${#sources[@]} == 0 )); then
+    warn "No APT source files found in /etc/apt/sources.list or /etc/apt/sources.list.d."
+    return 1
+  fi
+
   local all_text
   all_text="$(cat "${sources[@]}" 2>/dev/null || true)"
 
@@ -176,6 +181,10 @@ has_suite_sources() {
   [[ -f /etc/apt/sources.list ]] && sources+=("/etc/apt/sources.list")
   if compgen -G "/etc/apt/sources.list.d/*.list" >/dev/null; then
     sources+=(/etc/apt/sources.list.d/*.list)
+  fi
+
+  if (( ${#sources[@]} == 0 )); then
+    return 1
   fi
 
   local all_text


### PR DESCRIPTION
### Motivation
- Prevent the installer from reading stdin or behaving unpredictably when no APT source files exist by failing fast during source checks.
- Make `check_nonfree_sources()` and `has_suite_sources()` more robust against systems without `/etc/apt/sources.list` or files in `/etc/apt/sources.list.d`.

### Description
- Add an early check in `check_nonfree_sources()` to test `(( ${#sources[@]} == 0 ))`, emit a `warn` and `return 1` when no source files are found.
- Add the same empty-source check to `has_suite_sources()` and return `1` when there are no source files.
- Changes are made in `install-nvidia-cuda.sh` and preserve existing behavior when sources are present.

### Testing
- No automated tests were run for this change.
- Manual/interactive testing was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f4bc4b84c832886c4e29fd4b217ed)